### PR TITLE
refactor: accept tfvars path in pipelines

### DIFF
--- a/file.tf
+++ b/file.tf
@@ -129,7 +129,7 @@ resource "jenkins_job" "terraform_jenkins" {
     scm_repository_url = "https://github.com/nodadyoushutup/terraform-jenkins"
     script_path        = "pipeline.jenkins"
     auto_approve       = local.job_parameters.terraform_jenkins.auto_approve
-    service            = local.job_parameters.terraform_jenkins.service
+    tfvars             = local.job_parameters.terraform_jenkins.tfvars
   })
 }
 
@@ -142,6 +142,6 @@ resource "jenkins_job" "terraform_proxmox" {
     scm_repository_url = "https://github.com/nodadyoushutup/terraform-proxmox"
     script_path        = "pipeline.jenkins"
     auto_approve       = local.job_parameters.terraform_proxmox.auto_approve
-    service            = local.job_parameters.terraform_proxmox.service
+    tfvars             = local.job_parameters.terraform_proxmox.tfvars
   })
 }

--- a/job.xml
+++ b/job.xml
@@ -15,9 +15,9 @@
                                         <defaultValue>${auto_approve}</defaultValue>
                                 </hudson.model.BooleanParameterDefinition>
                                 <hudson.model.StringParameterDefinition>
-                                        <name>SERVICE</name>
-                                        <description>Service name whose tfvars file will be used</description>
-                                        <defaultValue>${service}</defaultValue>
+                                        <name>TFVARS</name>
+                                        <description>Path to the tfvars file (relative or absolute)</description>
+                                        <defaultValue>${tfvars}</defaultValue>
                                         <trim>false</trim>
                                 </hudson.model.StringParameterDefinition>
                         </parameterDefinitions>

--- a/local.tf
+++ b/local.tf
@@ -144,11 +144,11 @@ locals {
   job_parameters = {
     terraform_jenkins = {
       auto_approve = false
-      service      = ""
+      tfvars       = ""
     }
     terraform_proxmox = {
       auto_approve = false
-      service      = "proxmox"
+      tfvars       = "~/.tfvars/proxmox.tfvars"
     }
   }
 }

--- a/pipeline.jenkins
+++ b/pipeline.jenkins
@@ -10,8 +10,8 @@ pipeline {
       steps {
         script {
           def varFile = ''
-          if (params.SERVICE?.trim()) {
-            varFile = "${env.HOME}/.tfvars/${params.SERVICE}.tfvars"
+          if (params.TFVARS?.trim()) {
+            varFile = params.TFVARS.trim()
           } else {
             varFile = sh(
               script: '''
@@ -20,10 +20,10 @@ pipeline {
                 if [ ${#matches[@]} -eq 1 ]; then
                   echo ${matches[0]}
                 elif [ ${#matches[@]} -eq 0 ]; then
-                  echo "[ERR] No *.tfvars found in current directory. Provide a service." >&2
+                  echo "[ERR] No *.tfvars found in current directory. Provide a tfvars path." >&2
                   exit 1
                 else
-                  echo "[ERR] Multiple *.tfvars found in current directory. Specify a service." >&2
+                  echo "[ERR] Multiple *.tfvars found in current directory. Specify a tfvars file." >&2
                   exit 1
                 fi
               ''',


### PR DESCRIPTION
## Summary
- accept direct tfvars path instead of service name in Terraform pipelines
- propagate tfvars parameter through Jenkins jobs and Terraform locals

## Testing
- `shellcheck pipeline.sh`
- `terraform fmt -check file.tf local.tf`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68b32dda0278832c9648377ccb1c6829