### PR TITLE
Add tfvars parameters and provider config variables

### DIFF
--- a/docker/main.tf
+++ b/docker/main.tf
@@ -177,8 +177,8 @@ resource "docker_service" "jenkins_agent" {
 resource "null_resource" "wait_for_service" {
   depends_on = [docker_service.jenkins_controller]
   triggers = {
-    endpoint = "http://192.168.1.110:8080/whoAmI/api/json?tree=authenticated"
-    delay = "5"
+    endpoint     = "http://192.168.1.110:8080/whoAmI/api/json?tree=authenticated"
+    delay        = "5"
     max_attempts = "60"
     script_sha1  = filesha1("${path.module}/script/healthcheck.sh")
   }

--- a/docker/provider.tf
+++ b/docker/provider.tf
@@ -4,16 +4,10 @@ terraform {
       source  = "kreuzwerker/docker"
       version = "3.6.2"
     }
-
   }
 }
 
 provider "docker" {
-  host = "ssh://nodadyoushutup@192.168.1.110:22"
-  ssh_opts = [
-    "-o", "StrictHostKeyChecking=no",
-    "-o", "UserKnownHostsFile=/dev/null",
-    "-i", "~/.ssh/id_rsa"
-  ]
+  host     = var.provider_config.host
+  ssh_opts = var.provider_config.ssh_opts
 }
-

--- a/docker/variables.tf
+++ b/docker/variables.tf
@@ -1,0 +1,4 @@
+variable "provider_config" {
+  description = "Configuration for the Docker provider"
+  type        = map(any)
+}

--- a/jenkins/job.xml
+++ b/jenkins/job.xml
@@ -14,6 +14,18 @@
                                         <description>Pass -auto-approve to terraform apply</description>
                                         <defaultValue>${auto_approve}</defaultValue>
                                 </hudson.model.BooleanParameterDefinition>
+                                <hudson.model.StringParameterDefinition>
+                                        <name>DOCKER_TFVARS_FILE</name>
+                                        <description>Path to Docker tfvars file</description>
+                                        <defaultValue>${docker_tfvars}</defaultValue>
+                                        <trim>false</trim>
+                                </hudson.model.StringParameterDefinition>
+                                <hudson.model.StringParameterDefinition>
+                                        <name>JENKINS_TFVARS_FILE</name>
+                                        <description>Path to Jenkins tfvars file</description>
+                                        <defaultValue>${jenkins_tfvars}</defaultValue>
+                                        <trim>false</trim>
+                                </hudson.model.StringParameterDefinition>
                         </parameterDefinitions>
                 </hudson.model.ParametersDefinitionProperty>
         </properties>

--- a/jenkins/local.tf
+++ b/jenkins/local.tf
@@ -1,7 +1,9 @@
 locals {
   job_parameters = {
     terraform_jenkins = {
-      auto_approve = true
+      auto_approve   = true
+      docker_tfvars  = "~/.tfvars/docker/jenkins.tfvars"
+      jenkins_tfvars = "~/.tfvars/jenkins.tfvars"
     }
     terraform_proxmox = {
       auto_approve = true

--- a/jenkins/main.tf
+++ b/jenkins/main.tf
@@ -1,21 +1,25 @@
 resource "jenkins_job" "terraform_jenkins" {
-  name       = "terraform-jenkins"
+  name = "terraform-jenkins"
   template = templatefile("${path.module}/job.xml", {
     description        = "Jenkins assets"
     project_url        = "https://github.com/nodadyoushutup/terraform-jenkins"
     scm_repository_url = "https://github.com/nodadyoushutup/terraform-jenkins"
     script_path        = "jenkins/pipeline.jenkins"
     auto_approve       = local.job_parameters.terraform_jenkins.auto_approve
+    docker_tfvars      = local.job_parameters.terraform_jenkins.docker_tfvars
+    jenkins_tfvars     = local.job_parameters.terraform_jenkins.jenkins_tfvars
   })
 }
 
 resource "jenkins_job" "terraform_proxmox" {
-  name       = "terraform-proxmox"
+  name = "terraform-proxmox"
   template = templatefile("${path.module}/job.xml", {
     description        = "Proxmox assets"
     project_url        = "https://github.com/nodadyoushutup/terraform-proxmox"
     scm_repository_url = "https://github.com/nodadyoushutup/terraform-proxmox"
     script_path        = "pipeline.jenkins"
     auto_approve       = local.job_parameters.terraform_proxmox.auto_approve
+    docker_tfvars      = ""
+    jenkins_tfvars     = ""
   })
 }

--- a/jenkins/provider.tf
+++ b/jenkins/provider.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "jenkins" {
-  server_url = "http://192.168.1.110:8080/"
-  username   = "admin"
-  password   = "password"
+  server_url = var.provider_config.server_url
+  username   = var.provider_config.username
+  password   = var.provider_config.password
 }

--- a/jenkins/variables.tf
+++ b/jenkins/variables.tf
@@ -1,0 +1,4 @@
+variable "provider_config" {
+  description = "Configuration for the Jenkins provider"
+  type        = map(any)
+}

--- a/pipeline.jenkins
+++ b/pipeline.jenkins
@@ -2,6 +2,8 @@ pipeline {
   agent any
   parameters {
     booleanParam(name: 'AUTO_APPROVE', defaultValue: false, description: 'Pass -auto-approve to terraform apply')
+    string(name: 'DOCKER_TFVARS_FILE', defaultValue: '~/.tfvars/docker/jenkins.tfvars', description: 'Path to Docker tfvars file')
+    string(name: 'JENKINS_TFVARS_FILE', defaultValue: '~/.tfvars/jenkins.tfvars', description: 'Path to Jenkins tfvars file')
   }
   stages {
     stage('Docker') {
@@ -9,10 +11,10 @@ pipeline {
         script {
           sh 'terraform -chdir=docker init -input=false'
           if (params.AUTO_APPROVE) {
-            sh 'terraform -chdir=docker apply -input=false -auto-approve'
+            sh "terraform -chdir=docker apply -input=false -auto-approve -var-file=${params.DOCKER_TFVARS_FILE}"
           } else {
-            sh 'terraform -chdir=docker plan -input=false'
-            sh 'terraform -chdir=docker apply'
+            sh "terraform -chdir=docker plan -input=false -var-file=${params.DOCKER_TFVARS_FILE}"
+            sh "terraform -chdir=docker apply -var-file=${params.DOCKER_TFVARS_FILE}"
           }
         }
       }
@@ -22,10 +24,10 @@ pipeline {
         script {
           sh 'terraform -chdir=jenkins init -input=false'
           if (params.AUTO_APPROVE) {
-            sh 'terraform -chdir=jenkins apply -input=false -auto-approve'
+            sh "terraform -chdir=jenkins apply -input=false -auto-approve -var-file=${params.JENKINS_TFVARS_FILE}"
           } else {
-            sh 'terraform -chdir=jenkins plan -input=false'
-            sh 'terraform -chdir=jenkins apply'
+            sh "terraform -chdir=jenkins plan -input=false -var-file=${params.JENKINS_TFVARS_FILE}"
+            sh "terraform -chdir=jenkins apply -var-file=${params.JENKINS_TFVARS_FILE}"
           }
         }
       }


### PR DESCRIPTION
## Summary
- add DOCKER_TFVARS_FILE and JENKINS_TFVARS_FILE job parameters with defaults
- wire docker and Jenkins providers to provider_config variables
- consume tfvars parameters in the Jenkins pipeline

## Testing
- `terraform -chdir=docker fmt -check && terraform -chdir=jenkins fmt -check`
- `terraform -chdir=docker validate`
- `terraform -chdir=jenkins validate`


------
https://chatgpt.com/codex/tasks/task_e_68b34311734c832cbbbee8d27999c7fd