### PR TITLE
chore: add param validation stage

### DIFF
--- a/pipeline/pipeline.jenkins
+++ b/pipeline/pipeline.jenkins
@@ -1,11 +1,26 @@
 pipeline {
   agent any
-  parameters {
-    booleanParam(name: 'AUTO_APPROVE', defaultValue: false, description: 'Pass -auto-approve to terraform apply')
-    string(name: 'DOCKER_TFVARS_FILE', defaultValue: '~/.tfvars/docker/jenkins.tfvars', description: 'Path to Docker tfvars file')
-    string(name: 'APP_TFVARS_FILE', defaultValue: '~/.tfvars/jenkins.tfvars', description: 'Path to Jenkins tfvars file')
-  }
   stages {
+    stage('Validate Parameters') {
+      steps {
+        script {
+          if (params.AUTO_APPROVE == null) {
+            error 'AUTO_APPROVE parameter is not set'
+          }
+
+          def files = [
+            DOCKER_TFVARS_FILE: params.DOCKER_TFVARS_FILE,
+            APP_TFVARS_FILE   : params.APP_TFVARS_FILE
+          ]
+          files.each { name, path ->
+            if (!path?.trim()) {
+              error "${name} parameter is not set"
+            }
+            sh "test -f ${path}"
+          }
+        }
+      }
+    }
     stage('Docker') {
       steps {
         script {

--- a/pipeline/pipeline.sh
+++ b/pipeline/pipeline.sh
@@ -37,6 +37,12 @@ done
 
 command -v terraform >/dev/null 2>&1 || { echo "[ERR] terraform not found in PATH" >&2; exit 127; }
 
+echo "[STAGE 0] verify params"
+[[ -n "$DOCKER_TFVARS" ]] || { echo "[ERR] DOCKER_TFVARS is not set" >&2; exit 1; }
+[[ -f "$DOCKER_TFVARS" ]] || { echo "[ERR] DOCKER_TFVARS file not found: $DOCKER_TFVARS" >&2; exit 1; }
+[[ -n "$APP_TFVARS" ]] || { echo "[ERR] APP_TFVARS is not set" >&2; exit 1; }
+[[ -f "$APP_TFVARS" ]] || { echo "[ERR] APP_TFVARS file not found: $APP_TFVARS" >&2; exit 1; }
+
 apply_dir() {
   local DIR="$1"
   local TFVARS="$2"


### PR DESCRIPTION
## Summary
- remove parameter declaration block from Jenkins pipeline script
- add parameter validation stages to Jenkins and bash pipelines

## Testing
- `bash -n pipeline/pipeline.sh`
- `apt-get install -y groovy` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_68b34fbeeeb4832cb84209330b2598a7