### PR TITLE
Refactor agent provisioning with module

### DIFF
--- a/docker/modules/jenkins-agent/main.tf
+++ b/docker/modules/jenkins-agent/main.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_providers {
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+  }
+}
+
+resource "docker_volume" "agent" {
+  name = "jenkins-agent-${var.name}"
+}
+
+resource "docker_service" "agent" {
+  name = "jenkins-agent-${var.name}"
+
+  task_spec {
+    container_spec {
+      image = "ghcr.io/nodadyoushutup/jenkins-agent:3283.v92c105e0f819-7"
+
+      env = {
+        JENKINS_URL        = var.jenkins_url
+        JENKINS_AGENT_NAME = var.name
+      }
+
+      mounts {
+        target = "/home/jenkins"
+        source = docker_volume.agent.name
+        type   = "volume"
+      }
+
+      mounts {
+        target = "/dev/kvm"
+        source = "/dev/kvm"
+        type   = "bind"
+      }
+
+      mounts {
+        target = "/home/jenkins/.jenkins"
+        source = pathexpand("~/.jenkins")
+        type   = "bind"
+      }
+
+      mounts {
+        target = "/home/jenkins/.ssh"
+        source = pathexpand("~/.ssh")
+        type   = "bind"
+      }
+
+      mounts {
+        target = "/home/jenkins/.kube"
+        source = pathexpand("~/.kube")
+        type   = "bind"
+      }
+
+      mounts {
+        target = "/home/jenkins/.tfvars"
+        source = pathexpand("~/.tfvars")
+        type   = "bind"
+      }
+
+      configs {
+        config_id   = var.agent_entrypoint_config_id
+        config_name = var.agent_entrypoint_config_name
+        file_name   = "/agent-entrypoint.sh"
+        file_mode   = 511
+      }
+
+      dns_config {
+        nameservers = ["1.1.1.1", "8.8.8.8"]
+      }
+
+      command = ["/bin/sh", "-c", "/agent-entrypoint.sh"]
+    }
+  }
+}

--- a/docker/modules/jenkins-agent/variables.tf
+++ b/docker/modules/jenkins-agent/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  description = "Name of the Jenkins agent"
+  type        = string
+}
+
+variable "jenkins_url" {
+  description = "URL of the Jenkins controller"
+  type        = string
+}
+
+variable "agent_entrypoint_config_id" {
+  description = "ID of the Docker config containing the agent entrypoint script"
+  type        = string
+}
+
+variable "agent_entrypoint_config_name" {
+  description = "Name of the Docker config containing the agent entrypoint script"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- turn agent definition into reusable module
- loop through Jenkins node names to provision agents and volumes dynamically

## Testing
- `terraform fmt docker/main.tf docker/modules/jenkins-agent/main.tf docker/modules/jenkins-agent/variables.tf`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68b3601a6bf4832ca5b2da95076f8e43